### PR TITLE
Fix "Save All Slected Assets" typo

### DIFF
--- a/ViewModels/AssetTypeListViewModel.cs
+++ b/ViewModels/AssetTypeListViewModel.cs
@@ -97,7 +97,7 @@ namespace UWP_Visual_Asset_Generator.ViewModels
         {
             if (App.mainViewModel.OutputFolder != null)
             {
-                if (await ShowDialog("Save All Slected Assets", "This will overwrite any existing files in " + App.mainViewModel.OutputFolder.DisplayName,"Yes","No"))
+                if (await ShowDialog("Save All Selected Assets", "This will overwrite any existing files in " + App.mainViewModel.OutputFolder.DisplayName,"Yes","No"))
                 {
                     try
                     {


### PR DESCRIPTION
Just fixing a typo that caught my eye when using the app. Thanks for building this tool!